### PR TITLE
Release version 1.3.4-0ubuntu1 to Groovy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-containerd (1.3.4-0ubuntu1) UNRELEASED; urgency=medium
+containerd (1.3.4-0ubuntu1) groovy; urgency=medium
 
   * New upstream release.
   * d/p/0001-Improve-host-fallback-behaviour-in-docker-remote.patch: drop


### PR DESCRIPTION
Update target distribution in d/changelog.

BTW version 1.3.4-0ubuntu1 already migrated to Groovy release pocket.