### PR TITLE
Ubuntu fix build on riscv64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd (1.3.4-0ubuntu2) UNRELEASED; urgency=medium
+
+  * Add a patch to not use -buildmode=pie on riscv64
+  * d/rules: check for DEB_BUILD_ARCH to set variables to build on riscv64
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Wed, 20 May 2020 19:19:41 -0300
+
 containerd (1.3.4-0ubuntu1) groovy; urgency=medium
 
   * New upstream release.

--- a/debian/patches/4277-fix-build-on-riscv64.patch
+++ b/debian/patches/4277-fix-build-on-riscv64.patch
@@ -1,0 +1,19 @@
+Description: Fix FTBFS on riscv64
+ riscv64 does not support -buildmode=pie option.
+Author: Lucas Kanashiro <kanashiro@ubuntu.com>
+Forwarded: https://github.com/containerd/containerd/pull/4277
+Last-Updated: 2020-05-20
+
+--- a/Makefile.linux
++++ b/Makefile.linux
+@@ -20,7 +20,9 @@
+ 
+ # check GOOS for cross compile builds
+ ifeq ($(GOOS),linux)
+-	GO_GCFLAGS += -buildmode=pie
++	ifneq ($(GOARCH),riscv64)
++		GO_GCFLAGS += -buildmode=pie
++	endif
+ endif
+ 
+ # amd64 supports go test -race

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 preserve-debug-info.patch
 4134-update-etcd-bbolt.patch
+4277-fix-build-on-riscv64.patch

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ export GOCACHE := $(CURDIR)/.gocache
 
 # riscv64 doesn't support cgo
 # https://github.com/golang/go/issues/36641
-ifeq (0, $(shell go env CGO_ENABLED))
+ifeq (riscv64, $(DEB_BUILD_ARCH))
 TAGS += no_btrfs
 SKIP += github.com/containerd/containerd/snapshots/btrfs
 endif


### PR DESCRIPTION
Moving the riscv64 build failure discussion to this PR. Here I did:

* Added a patch already applied by upstream (https://github.com/containerd/containerd/pull/4277)
* Changed the logic in `debian/rules` to set the `TAGS` and `SKIP` variables. Now it is checking for `GOARCH` instead of `CGO_ENABLED`.

This [comment](https://github.com/tianon/debian-containerd/pull/2#issuecomment-631727936) might be relevant to understand why I did that.