### PR TITLE
Ubuntu fix build on riscv64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-containerd (1.3.4-0ubuntu3) UNRELEASED; urgency=medium
+containerd (1.3.4-0ubuntu3) groovy; urgency=medium
 
   * Add a patch to fix the gc/scheduler flaky test on riscv64
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd (1.3.4-0ubuntu3) UNRELEASED; urgency=medium
+
+  * Add a patch to fix the gc/scheduler flaky test on riscv64
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Thu, 21 May 2020 18:48:48 -0300
+
 containerd (1.3.4-0ubuntu2) groovy; urgency=medium
 
   * Add a patch to not use -buildmode=pie on riscv64

--- a/debian/patches/e859b8a-gc-increase-sleep-time-in-test.patch
+++ b/debian/patches/e859b8a-gc-increase-sleep-time-in-test.patch
@@ -1,0 +1,37 @@
+From e859b8a92b58499b4681cb96dae74f2f3bb50a70 Mon Sep 17 00:00:00 2001
+From: Shengjing Zhu <zhsj@debian.org>
+Date: Wed, 15 Jan 2020 18:23:37 +0800
+Subject: [PATCH] gc: increase sleep time in test
+
+Fix some flaky tests.
+
+Signed-off-by: Shengjing Zhu <zhsj@debian.org>
+
+Origin: upstream, https://github.com/containerd/containerd/commit/e859b8a
+Reviewed-By: Lucas Kanashiro <kanashiro@ubuntu.com>
+Last-Updated: 2020-05-21
+
+---
+ gc/scheduler/scheduler_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/gc/scheduler/scheduler_test.go
++++ b/gc/scheduler/scheduler_test.go
+@@ -131,7 +131,7 @@
+ 
+ 	select {
+ 	case <-gcWait:
+-	case <-time.After(time.Millisecond * 10):
++	case <-time.After(time.Millisecond * 30):
+ 		t.Fatal("GC wait timed out")
+ 	}
+ 
+@@ -162,7 +162,7 @@
+ 	defer cancel()
+ 	go scheduler.run(ctx)
+ 
+-	time.Sleep(time.Millisecond * 5)
++	time.Sleep(time.Millisecond * 30)
+ 
+ 	if c := tc.runCount(); c != 1 {
+ 		t.Fatalf("unexpected gc run count %d, expected 1", c)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 preserve-debug-info.patch
 4134-update-etcd-bbolt.patch
 4277-fix-build-on-riscv64.patch
+e859b8a-gc-increase-sleep-time-in-test.patch


### PR DESCRIPTION
Final attempt to make it build on riscv64. I backported an upstream patch aiming to fix the flaky `github.com/containerd/containerd/gc/scheduler` test. I built it in my local riscv64 vm and it worked.