### PR TITLE
Update binary package name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+containerd (1.3.4-0ubuntu4) UNRELEASED; urgency=medium
+
+  * d/control: rename binary package with dev files and update
+    XS-Go-Import-Path. Now it is called
+    golang-github-containerd-containerd-dev instead of
+    golang-github-docker-containerd-dev.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Thu, 28 May 2020 17:05:30 -0300
+
 containerd (1.3.4-0ubuntu3) groovy; urgency=medium
 
   * Add a patch to fix the gc/scheduler flaky test on riscv64

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Standards-Version: 3.9.7
 Homepage: https://containerd.io
 Vcs-Git: https://github.com/tianon/debian-containerd.git -b ubuntu
 Vcs-Browser: https://github.com/tianon/debian-containerd/tree/ubuntu
-XS-Go-Import-Path: github.com/docker/containerd
+XS-Go-Import-Path: github.com/containerd/containerd
 
 Package: containerd
 Architecture: linux-any
@@ -29,7 +29,7 @@ Description: daemon to control runC
  .
  This package contains the binaries.
 
-Package: golang-github-docker-containerd-dev
+Package: golang-github-containerd-containerd-dev
 Architecture: all
 Depends: ${misc:Depends}
 Description: runC develpoment files


### PR DESCRIPTION
In Ubuntu we have not updated the namespace of this project from `github.com/docker/containerd` to `github.com/containerd/containerd`. I noticed this issue while checking why the `cadvisor` source package is FTBFS because of a missing build dependency: `golang-github-containerd-containerd-dev` (check the build log [here](https://launchpadlibrarian.net/477647965/buildlog_ubuntu-groovy-amd64.cadvisor_0.35.0+ds1-4_BUILDING.txt.gz)).

This PR has the following changes:

* Rename the binary package containing the dev files to `golang-github-containerd-containerd-dev`
* Update the `XS-Go-Import-Path` variable to match the namespace

autopkgtest is still happy with those changes:

```
autopkgtest [17:24:51]: @@@@@@@@@@@@@@@@@@@@ summary
basic-smoke          PASS
```

And here you have a PPA with the proposed package:

https://launchpad.net/~lucaskanashiro/+archive/ubuntu/groovy-containerd/+packages
