### PR TITLE
golang-race-detector-runtime is no longer available

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd (1.3.4-0ubuntu6) groovy; urgency=medium
+
+  * d/control: remove the golang-race-detector-runtime build dependency as the
+    package is no longer built from source with latest golang.
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 16 Jun 2020 10:12:13 +0200
+
 containerd (1.3.4-0ubuntu5) groovy; urgency=medium
 
   * Rename install file to match the new binary package name

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Uploaders: Tianon Gravi <tianon@debian.org>
 Build-Depends: debhelper (>= 9),
                go-md2man,
                golang-go (>= 2:1.10~),
-               golang-race-detector-runtime [amd64],
                libbtrfs-dev | btrfs-progs (<< 4.16.1~),
                libseccomp-dev,
                pkg-config


### PR DESCRIPTION
Remove it from build-dependencies.