### PR TITLE
Ubuntu: update to version 1.3.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
-containerd (1.3.6-0ubuntu1) UNRELEASED; urgency=medium
+containerd (1.3.6-0ubuntu1) groovy; urgency=medium
 
   * New upstream release.
+  * d/rules: remove vendor directory from the library package
 
  -- Lucas Kanashiro <kanashiro@ubuntu.com>  Sat, 11 Jul 2020 11:20:49 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd (1.3.6-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Sat, 11 Jul 2020 11:20:49 -0300
+
 containerd (1.3.4-0ubuntu6) groovy; urgency=medium
 
   * d/control: remove the golang-race-detector-runtime build dependency as the

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ endif
 override_dh_auto_configure:
 	# copy pristine source for "/usr/share/gocode" to get into "golang-github-containerd-containerd-dev" before we muddy it with build artifacts, etc
 	mkdir -p .pristine-source
-	tar -c --exclude=debian --exclude=.pc --exclude=.pristine-source . | tar -xC .pristine-source
+	tar -c --exclude=debian --exclude=.pc --exclude=.pristine-source --exclude=vendor . | tar -xC .pristine-source
 	# set up GOPATH symlink farm
 	mkdir -p '$(OUR_GOPATH)/src/github.com/containerd'
 	ln -sfT '$(CURDIR)' '$(OUR_GOPATH)/src/github.com/containerd/containerd'


### PR DESCRIPTION
Import upstream version 1.3.6. Moreover, the vendor directory was removed from the library package since its inclusion has caused some issues discussed on #11.

I uploaded the package to this PPA:

https://launchpad.net/~lucaskanashiro/+archive/ubuntu/groovy-containerd/+packages

autopkgtest is still happy:

autopkgtest [13:23:35]: @@@@@@@@@@@@@@@@@@@@ summary
basic-smoke          PASS

