### PR TITLE
Add a Breaks for docker.io lower than 19.03.13-0ubuntu4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-containerd (1.3.7-0ubuntu4) UNRELEASED; urgency=medium
+containerd (1.3.7-0ubuntu4) hirsute; urgency=medium
 
   * d/control: add a Breaks for docker.io lower than 19.03.13-0ubuntu4.
     See LP #1870514. The previous versions stop the docker daemon when a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+containerd (1.3.7-0ubuntu4) UNRELEASED; urgency=medium
+
+  * d/control: add a Breaks for docker.io lower than 19.03.13-0ubuntu4.
+    See LP #1870514. The previous versions stop the docker daemon when a
+    containerd update is performed, this Breaks statement will make sure we
+    have a newer version which has the appropriate fix.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Mon, 07 Dec 2020 16:33:03 -0300
+
 containerd (1.3.7-0ubuntu3) groovy; urgency=medium
 
   * Build with Go 1.14 on riscv64 as 1.13 does not exist here. Adventurous

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ XS-Go-Import-Path: github.com/containerd/containerd
 Package: containerd
 Architecture: linux-any
 Depends: runc (>= 1.0.0~rc2~), ${misc:Depends}, ${shlibs:Depends}
+Breaks: docker.io (<< 19.03.13-0ubuntu4)
 Built-Using: ${misc:Built-Using}
 Description: daemon to control runC
  Containerd is a daemon to control runC, built for performance and density.


### PR DESCRIPTION
These changes will make sure users will have the appropriate version of docker.io which will not stop the daemon during containerd updates. The target is the Ubuntu development release (a.k.a. hirsute).

The idea is to coordinate and upload this containerd (version 1.3.7-0ubuntu4) and docker.io version 19.03.13-0ubuntu4 to Hirsute all together:

https://code.launchpad.net/~bryce/ubuntu/+source/docker.io/+git/docker.io/+merge/394913

FWIW this is the Ubuntu bug:

https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1870514