### PR TITLE
Ubuntu import 1.4.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,12 @@ containerd (1.4.4-0ubuntu1) UNRELEASED; urgency=medium
   * New upstream release.
     - It contains a fix for CVE-2021-21334 along with various other minor
       issues.
+  * Refresh preserve-debug-info.patch
+  * d/rules: set GO111MODULE to auto. In Go 1.16, which is the default in
+    Hirsute now, the packages are built in module-aware mode. Since containerd
+    does not have a go.mod file in its source tree it FTBFS. Setting GO111MODULE
+    to auto we can have the previous behavior which is enable module-aware mode
+    only if the go.mod file exists.
 
  -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 10 Mar 2021 11:45:18 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+containerd (1.4.4-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+    - It contains a fix for CVE-2021-21334 along with various other minor
+      issues.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 10 Mar 2021 11:45:18 -0300
+
 containerd (1.4.3-0ubuntu1) hirsute; urgency=medium
 
   * New upstream release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-containerd (1.4.4-0ubuntu1) UNRELEASED; urgency=medium
+containerd (1.4.4-0ubuntu1) hirsute; urgency=medium
 
   * New upstream release.
     - It contains a fix for CVE-2021-21334 along with various other minor

--- a/debian/patches/preserve-debug-info.patch
+++ b/debian/patches/preserve-debug-info.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -52,7 +52,6 @@
+@@ -53,7 +53,6 @@
  endif
  
  ifndef GODEBUG

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,9 @@ OUR_GOPATH := $(CURDIR)/.gopath
 export GOPATH := $(OUR_GOPATH)
 export GOCACHE := $(CURDIR)/.gocache
 
+# https://blog.golang.org/go116-module-changes (TODO figure out a new solution for Go 1.17+)
+export GO111MODULE := auto
+
 # riscv64 doesn't support cgo
 # https://github.com/golang/go/issues/36641
 ifeq (riscv64, $(DEB_BUILD_ARCH))


### PR DESCRIPTION
Version 1.4.4 is a bug fix release which is also addressing CVE-2021-21334.

I uploaded the package to this PPA:

https://launchpad.net/~lucaskanashiro/+archive/ubuntu/docker-20.10/+packages

autopkgtest is still happy:

autopkgtest [16:07:05]: @@@@@@@@@@@@@@@@@@@@ summary
basic-smoke          PASS
