### PR TITLE
d/control: Create transitional package golang-github-docker-containerd-dev. (Bionic)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+containerd (1.4.4-0ubuntu1~18.04.2) bionic; urgency=medium
+
+  * d/control: Create transitional package golang-github-docker-containerd-dev
+    for golang-github-containerd-containerd-dev.
+
+ -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Mon, 29 Mar 2021 14:46:10 -0400
+
 containerd (1.4.4-0ubuntu1~18.04.1) bionic; urgency=medium
 
   * Backport version 1.4.4-0ubuntu1 from Hirsute (LP: #1919322).

--- a/debian/control
+++ b/debian/control
@@ -40,3 +40,12 @@ Description: runC develpoment files
  migration of containers.
  .
  This package provides development files.
+
+Package: golang-github-docker-containerd-dev
+Section: oldlibs
+Priority: optional
+Architecture: all
+Depends: golang-github-containerd-containerd-dev, ${misc:Depends}
+Description: Transitional package for golang-github-containerd-containerd-dev
+ This is a transitional package to ease upgrades to the
+ golang-github-containerd-containerd-dev package. It can safely be removed.


### PR DESCRIPTION
Transitional package for golang-github-containerd-containerd-dev.

Re. https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1919322