### PR TITLE
Delete golang-github-docker-containerd-dev.install (Focal)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ containerd (1.4.4-0ubuntu1~20.04.2) focal; urgency=medium
 
   * d/control: Create transitional package golang-github-docker-containerd-dev
     for golang-github-containerd-containerd-dev.
+  * d/golang-github-docker-containerd-dev.install: Remove file.
 
  -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Mon, 29 Mar 2021 14:41:57 -0400
 

--- a/debian/golang-github-docker-containerd-dev.install
+++ b/debian/golang-github-docker-containerd-dev.install
@@ -1,1 +1,0 @@
-usr/share/gocode/src


### PR DESCRIPTION
The `.install` file was still present in the package.