### PR TITLE
Import 1.5.2 to Focal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+containerd (1.5.2-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Fri, 21 May 2021 17:11:42 -0300
+
 containerd (1.4.4-0ubuntu1~20.04.2) focal; urgency=medium
 
   * d/control: Create transitional package golang-github-docker-containerd-dev

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
 containerd (1.5.2-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
 
   * New upstream release.
+  * d/p/skip-tests-with-privilege.patch: add a patch to skip tests which
+    require a certain level of privilege not achievable in the build
+    environment.
+  * d/rules: set GO111MODULE variable to off to avoid Internet connection.
 
  -- Lucas Kanashiro <kanashiro@ubuntu.com>  Fri, 21 May 2021 17:11:42 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 containerd (1.5.2-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
 
-  * New upstream release.
+  * New upstream release, backport from Impish (LP: #1931464).
   * d/p/skip-tests-with-privilege.patch: add a patch to skip tests which
     require a certain level of privilege not achievable in the build
     environment.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-containerd (1.5.2-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
+containerd (1.5.2-0ubuntu1~20.04.1) focal; urgency=medium
 
   * New upstream release, backport from Impish (LP: #1931464).
   * d/p/skip-tests-with-privilege.patch: add a patch to skip tests which

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
+skip-tests-with-privilege.patch
 preserve-debug-info.patch

--- a/debian/patches/skip-tests-with-privilege.patch
+++ b/debian/patches/skip-tests-with-privilege.patch
@@ -1,0 +1,149 @@
+Description: Skip tests which require a certain level of privilege
+ During build we cannot bindmount sysfs and cgroupfs in a chroot which leads to
+ failures.
+Author: Lucas Kanashiro <kanashiro@ubuntu.com>
+Forwarded: not-needed
+Last-Updated: 2021-05-20
+
+--- a/pkg/cri/server/container_create_linux_test.go
++++ b/pkg/cri/server/container_create_linux_test.go
+@@ -187,6 +187,7 @@
+ }
+ 
+ func TestContainerCapabilities(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -267,6 +268,7 @@
+ }
+ 
+ func TestContainerSpecTty(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -289,6 +291,7 @@
+ }
+ 
+ func TestContainerSpecDefaultPath(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -311,6 +314,7 @@
+ }
+ 
+ func TestContainerSpecReadonlyRootfs(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -328,6 +332,7 @@
+ }
+ 
+ func TestContainerSpecWithExtraMounts(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -389,6 +394,7 @@
+ }
+ 
+ func TestContainerAndSandboxPrivileged(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -591,6 +597,7 @@
+ }
+ 
+ func TestPrivilegedBindMount(t *testing.T) {
++	t.Skip("It requires privilege to mount sysfs and cgroupfs. Not achievable during the build.")
+ 	testPid := uint32(1234)
+ 	c := newTestCRIService()
+ 	testSandboxID := "sandbox-id"
+@@ -741,6 +748,7 @@
+ }
+ 
+ func TestPidNamespace(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testPid := uint32(1234)
+ 	testSandboxID := "sandbox-id"
+@@ -782,6 +790,7 @@
+ }
+ 
+ func TestNoDefaultRunMount(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testPid := uint32(1234)
+ 	testSandboxID := "sandbox-id"
+@@ -1086,6 +1095,7 @@
+ }
+ 
+ func TestMaskedAndReadonlyPaths(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -1174,6 +1184,7 @@
+ }
+ 
+ func TestHostname(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testSandboxID := "sandbox-id"
+ 	testContainerName := "container-name"
+@@ -1305,6 +1316,7 @@
+ }
+ 
+ func TestPrivilegedDevices(t *testing.T) {
++	t.Skip("It requires privilege to test devices. Not achievable during the build.")
+ 	testPid := uint32(1234)
+ 	c := newTestCRIService()
+ 	testSandboxID := "sandbox-id"
+@@ -1367,6 +1379,7 @@
+ }
+ 
+ func TestBaseOCISpec(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	c := newTestCRIService()
+ 	baseLimit := int64(100)
+ 	c.baseOCISpecs = map[string]*oci.Spec{
+--- a/pkg/cri/server/container_create_test.go
++++ b/pkg/cri/server/container_create_test.go
+@@ -56,6 +56,7 @@
+ const testImageName = "container-image-name"
+ 
+ func TestGeneralContainerSpec(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	testID := "test-id"
+ 	testPid := uint32(1234)
+ 	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
+@@ -69,6 +70,7 @@
+ }
+ 
+ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	if goruntime.GOOS == "darwin" {
+ 		t.Skip("not implemented on Darwin")
+ 	}
+@@ -277,6 +279,7 @@
+ }
+ 
+ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
++	t.Skip("It requires HugeTLB controller enabled which requires mounting cgroupfs. Not achievable during the build.")
+ 	if goruntime.GOOS == "darwin" {
+ 		t.Skip("not implemented on Darwin")
+ 	}
+--- a/pkg/cri/server/container_update_resources_linux_test.go
++++ b/pkg/cri/server/container_update_resources_linux_test.go
+@@ -27,6 +27,7 @@
+ )
+ 
+ func TestUpdateOCILinuxResource(t *testing.T) {
++	t.Skip("It requires some privileges not achievable during the build.")
+ 	oomscoreadj := new(int)
+ 	*oomscoreadj = -500
+ 	for desc, test := range map[string]struct {

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,8 @@ export GOPATH := $(OUR_GOPATH)
 export GOCACHE := $(CURDIR)/.gocache
 
 # https://blog.golang.org/go116-module-changes (TODO figure out a new solution for Go 1.17+)
-export GO111MODULE := auto
+# GO111MODULE needs to be set to "off" to avoid checking modules information online
+export GO111MODULE := off
 
 # riscv64 doesn't support cgo
 # https://github.com/golang/go/issues/36641


### PR DESCRIPTION
To backport this package I needed to also set `GO111MODULE` to `off` to avoid searching for modules on the Internet.

PPA with the proposed package:

https://launchpad.net/~lucaskanashiro/+archive/ubuntu/container-stack/+packages

autopkgtest summary:

```
autopkgtest [17:36:33]: @@@@@@@@@@@@@@@@@@@@ summary
basic-smoke          PASS
```